### PR TITLE
Use /bin/bash as default shell

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     name={{ item.username }}
     group={{ item.group if item.group is defined else users_available[item.username]['group'] if users_available[item.username]['group'] is defined else item.username }}
     groups="{{ item.groups|join(',') if item.groups is defined else users_available[item.username]['groups']|join(',') if users_available[item.username]['groups'] is defined else omit }}"
-    shell="{{ item.shell|default(users_available[item.username]['shell'])|default(omit) }}"
+    shell="{{ item.shell|default(users_available[item.username]['shell'])|default("/bin/bash") }}"
     comment="{{ item.comment if item.comment is defined else users_available[item.username]['comment'] if users_available[item.username]['comment'] is defined else users_available[item.username]['name'] }}"
     uid="{{ item.uid|default(users_available[item.username]['uid']) if users_available[item.username]['uid'] is defined else omit }}"
     createhome=yes


### PR DESCRIPTION
As of now, when I create users they have no shell at all.
I propose to use /bin/bash by default.